### PR TITLE
feat(telegram): fleet-wide TELEGRAM_WEBHOOK_SECRET for all bots (SEC-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,16 @@ it chooses (e.g. `/bot`):
   reflect the **origin's** hostname, not the public-facing one you called. Check what `Host` your origin
   actually receives before registering through a proxied domain, or call `set-webhook` directly on the
   origin's own hostname if you want predictability.
-- Each bot's `BotSettings.WebhookSecretToken` (if configured) is sent as Telegram's `secret_token`, and
-  incoming webhook requests are checked against it (`X-Telegram-Bot-Api-Secret-Token` header). Registering
-  without one leaves that bot's webhook unauthenticated — anyone who learns/guesses the webhook URL can
-  POST forged updates. A warning is logged (not fatal) when this happens.
+- **Webhook authentication (SEC-4).** The `secret_token` registered with Telegram and verified on every
+  incoming request (`X-Telegram-Bot-Api-Secret-Token` header) is resolved per bot as: the bot's own
+  `BotSettings.WebhookSecretToken` if set, otherwise the **fleet-wide `TELEGRAM_WEBHOOK_SECRET`** env var.
+  So a single provisioned `TELEGRAM_WEBHOOK_SECRET` authenticates **every** bot's webhook with no per-bot
+  configuration; a bot needing an isolated secret can still override it via `WebhookSecretToken`. Once a
+  secret resolves, verification is strict — a missing or wrong header is rejected. If neither is set, the
+  webhook is unauthenticated (anyone who learns the URL can POST forged updates); a warning is logged on
+  every request (not fatal, unless `BotSettings.RequireWebhookSecret` is set, which makes it a hard reject).
+  After provisioning the secret, re-register each bot's webhook (`set-webhook`) so Telegram starts sending
+  the header.
 - Bot tokens are resolved from `<PLATFORM>_BOT_TOKEN_<CODE>` env vars by default (e.g.
   `TELEGRAM_BOT_TOKEN_MYBOT` for a bot registered with code `MyBot`), unless the consuming app
   wires a token explicitly.

--- a/telegram/tg_webhook_fleet_secret_test.go
+++ b/telegram/tg_webhook_fleet_secret_test.go
@@ -1,0 +1,88 @@
+package telegram
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bots-go-framework/bots-fw/botsfw"
+)
+
+// SEC-4 fleet-wide secret: a single TELEGRAM_WEBHOOK_SECRET (see EnvTelegramWebhookSecret)
+// authenticates every bot that sets no per-bot WebhookSecretToken, so one provisioned secret
+// secures the whole fleet's webhooks with no per-bot configuration. These tests cover
+// effectiveWebhookSecret (the resolver) and its effect on verifyWebhookSecretToken.
+
+// withFleetWebhookSecret overrides the fleet-wide TELEGRAM_WEBHOOK_SECRET resolver for the
+// duration of a test, without touching the real process environment.
+func withFleetWebhookSecret(t *testing.T, secret string) {
+	t.Helper()
+	prev := resolveFleetWebhookSecret
+	resolveFleetWebhookSecret = func() string { return secret }
+	t.Cleanup(func() { resolveFleetWebhookSecret = prev })
+}
+
+func TestEffectiveWebhookSecret_PerBotOverridesFleet(t *testing.T) {
+	withFleetWebhookSecret(t, "fleet-secret")
+	settings := &botsfw.BotSettings{Code: "somebot", WebhookSecretToken: "per-bot-secret"}
+	if got := effectiveWebhookSecret(settings); got != "per-bot-secret" {
+		t.Errorf("effectiveWebhookSecret() = %q, want the per-bot secret to win over the fleet secret", got)
+	}
+}
+
+func TestEffectiveWebhookSecret_FleetUsedWhenNoPerBot(t *testing.T) {
+	withFleetWebhookSecret(t, "fleet-secret")
+	settings := &botsfw.BotSettings{Code: "somebot"}
+	if got := effectiveWebhookSecret(settings); got != "fleet-secret" {
+		t.Errorf("effectiveWebhookSecret() = %q, want the fleet secret as fallback", got)
+	}
+}
+
+func TestEffectiveWebhookSecret_EmptyWhenNeitherSet(t *testing.T) {
+	withFleetWebhookSecret(t, "")
+	settings := &botsfw.BotSettings{Code: "somebot"}
+	if got := effectiveWebhookSecret(settings); got != "" {
+		t.Errorf("effectiveWebhookSecret() = %q, want empty when neither per-bot nor fleet secret is set", got)
+	}
+}
+
+func TestEffectiveWebhookSecret_NilSettingsFallsBackToFleet(t *testing.T) {
+	withFleetWebhookSecret(t, "fleet-secret")
+	if got := effectiveWebhookSecret(nil); got != "fleet-secret" {
+		t.Errorf("effectiveWebhookSecret(nil) = %q, want the fleet secret", got)
+	}
+}
+
+// Fleet secret authenticates a bot that sets no per-bot secret: a matching header passes;
+// a wrong or missing header is rejected. This is the fleet-wide "enforce" posture that takes
+// effect automatically once TELEGRAM_WEBHOOK_SECRET is provisioned and webhooks re-registered.
+func TestVerifyWebhookSecretToken_FleetSecretMatchingHeaderPasses(t *testing.T) {
+	withFleetWebhookSecret(t, "fleet-secret")
+	settings := &botsfw.BotSettings{Code: "somebot"} // no per-bot secret on purpose
+	req := newWebhookRequest(t, "fleet-secret")
+	if err := verifyWebhookSecretToken(context.Background(), req, settings); err != nil {
+		t.Errorf("verifyWebhookSecretToken() = %v, want nil for a header matching the fleet secret", err)
+	}
+}
+
+func TestVerifyWebhookSecretToken_FleetSecretWrongHeaderRejected(t *testing.T) {
+	withFleetWebhookSecret(t, "fleet-secret")
+	settings := &botsfw.BotSettings{Code: "somebot"}
+	req := newWebhookRequest(t, "wrong-value")
+	assertAuthFailed(t, verifyWebhookSecretToken(context.Background(), req, settings))
+}
+
+func TestVerifyWebhookSecretToken_FleetSecretMissingHeaderRejected(t *testing.T) {
+	withFleetWebhookSecret(t, "fleet-secret")
+	settings := &botsfw.BotSettings{Code: "somebot"}
+	req := newWebhookRequest(t, "")
+	assertAuthFailed(t, verifyWebhookSecretToken(context.Background(), req, settings))
+}
+
+// A per-bot secret overrides the fleet secret end-to-end: the header must match the per-bot
+// value, and the fleet value is NOT accepted for that bot.
+func TestVerifyWebhookSecretToken_PerBotOverridesFleet_FleetValueRejected(t *testing.T) {
+	withFleetWebhookSecret(t, "fleet-secret")
+	settings := &botsfw.BotSettings{Code: "somebot", WebhookSecretToken: "per-bot-secret"}
+	req := newWebhookRequest(t, "fleet-secret") // sending the fleet value, not the per-bot one
+	assertAuthFailed(t, verifyWebhookSecretToken(context.Background(), req, settings))
+}

--- a/telegram/tg_webhook_handler.go
+++ b/telegram/tg_webhook_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/strongo/logus"
 	"io"
 	"net/http"
+	"os"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -167,11 +168,12 @@ func (h tgWebhookHandler) SetWebhook(w http.ResponseWriter, r *http.Request) {
 		"refunded_payment",
 		"purchased_paid_media",
 	}
-	if webhookConfig.SecretToken = botContext.BotSettings.WebhookSecretToken; webhookConfig.SecretToken == "" {
-		// SEC-4: registering a webhook without a secret_token leaves it unauthenticated -
-		// verifyWebhookSecretToken will log a warning (or reject, if RequireWebhookSecret is
-		// set) on every incoming request until BotSettings.WebhookSecretToken is configured
-		// for this bot and the webhook is re-registered.
+	if webhookConfig.SecretToken = effectiveWebhookSecret(botContext.BotSettings); webhookConfig.SecretToken == "" {
+		// SEC-4: neither a per-bot BotSettings.WebhookSecretToken nor the fleet-wide
+		// TELEGRAM_WEBHOOK_SECRET (see effectiveWebhookSecret) is set, so this webhook is
+		// registered without a secret_token and stays unauthenticated - verifyWebhookSecretToken
+		// will log a warning (or reject, if RequireWebhookSecret is set) on every incoming
+		// request until a secret is configured and the webhook is re-registered.
 		logus.Warningf(ctx, "SEC-4 WARNING: registering webhook for bot %q WITHOUT a secret_token - its webhook will be unauthenticated", botCode)
 	}
 	var response tgbotapi.APIResponse
@@ -193,24 +195,50 @@ Parametes:
 	}
 }
 
+// EnvTelegramWebhookSecret is the environment variable holding the single, fleet-wide
+// Telegram webhook secret_token. It is applied to EVERY bot that does not set its own
+// BotSettings.WebhookSecretToken, so one provisioned secret authenticates the whole
+// fleet's webhooks with no per-bot configuration (SEC-4). A bot that needs an isolated
+// secret can still override it via BotSettings.WebhookSecretToken.
+const EnvTelegramWebhookSecret = "TELEGRAM_WEBHOOK_SECRET"
+
+// resolveFleetWebhookSecret reads the fleet-wide webhook secret. Indirected through a
+// package var so tests can substitute a value without mutating the process environment.
+var resolveFleetWebhookSecret = func() string { return os.Getenv(EnvTelegramWebhookSecret) }
+
+// effectiveWebhookSecret returns the secret_token to register (SetWebhook) and to verify
+// for a bot: the bot's own BotSettings.WebhookSecretToken when set, otherwise the
+// fleet-wide TELEGRAM_WEBHOOK_SECRET. It returns "" only when neither is configured, in
+// which case the webhook stays in the unauthenticated compat posture (see
+// verifyWebhookSecretToken). This is the single, framework-owned standard: hosts provision
+// one secret and every bot is authenticated uniformly.
+func effectiveWebhookSecret(settings *botsfw.BotSettings) string {
+	if settings != nil && settings.WebhookSecretToken != "" {
+		return settings.WebhookSecretToken
+	}
+	return resolveFleetWebhookSecret()
+}
+
 // verifyWebhookSecretToken checks the X-Telegram-Bot-Api-Secret-Token header Telegram sends
-// on every webhook call against the secret configured for this bot (see SEC-4: without this
+// on every webhook call against the secret resolved for this bot (see SEC-4: without this
 // check, anyone who knows/guesses a bot's webhook URL can POST forged updates and be treated
 // as any Telegram user, since botID/`?id=` is a public, non-secret value - the bot's own
-// @username).
+// @username). The expected secret is effectiveWebhookSecret(settings): the per-bot
+// WebhookSecretToken if set, else the fleet-wide TELEGRAM_WEBHOOK_SECRET.
 //
-// Compat posture: if no secret is configured for the bot (settings.WebhookSecretToken == ""),
-// this does NOT block the request - existing deployments that haven't rolled out a secret yet
-// keep working - but it logs a high-visibility warning on every single request so the gap is
-// impossible to miss in logs, unless settings.RequireWebhookSecret is set, in which case an
-// unconfigured secret is treated as a hard misconfiguration and the request is rejected.
-// Once a secret IS configured, verification is always strictly enforced.
+// Compat posture: if no secret resolves for the bot - neither a per-bot WebhookSecretToken
+// nor the fleet-wide TELEGRAM_WEBHOOK_SECRET - this does NOT block the request (existing
+// deployments that haven't rolled out a secret yet keep working) but logs a high-visibility
+// warning on every single request so the gap is impossible to miss, unless
+// settings.RequireWebhookSecret is set, in which case an unconfigured secret is a hard
+// misconfiguration and the request is rejected. Once a secret IS configured (per-bot or
+// fleet-wide), verification is always strictly enforced.
 func verifyWebhookSecretToken(ctx context.Context, r *http.Request, settings *botsfw.BotSettings) error {
 	if settings == nil { // defensive: should not happen for a bot resolved via BotContextProvider
 		logus.Warningf(ctx, "SEC-4 WARNING: BotSettings is nil, cannot verify %s header - treating as unauthenticated", TelegramWebhookSecretTokenHeader)
 		return nil
 	}
-	expected := settings.WebhookSecretToken
+	expected := effectiveWebhookSecret(settings)
 	if expected == "" {
 		if settings.RequireWebhookSecret {
 			logus.Criticalf(ctx,

--- a/telegram/tg_webhook_secret_token_test.go
+++ b/telegram/tg_webhook_secret_token_test.go
@@ -49,6 +49,7 @@ func TestVerifyWebhookSecretToken_MissingHeaderRejectedWhenSecretConfigured(t *t
 }
 
 func TestVerifyWebhookSecretToken_NoSecretConfigured_CompatAllowsByDefault(t *testing.T) {
+	withFleetWebhookSecret(t, "") // no fleet-wide secret either, so nothing resolves
 	settings := &botsfw.BotSettings{Code: "somebot"} // WebhookSecretToken left empty on purpose
 	req := newWebhookRequest(t, "")
 	if err := verifyWebhookSecretToken(context.Background(), req, settings); err != nil {
@@ -57,6 +58,7 @@ func TestVerifyWebhookSecretToken_NoSecretConfigured_CompatAllowsByDefault(t *te
 }
 
 func TestVerifyWebhookSecretToken_NoSecretConfigured_RequireWebhookSecretRejects(t *testing.T) {
+	withFleetWebhookSecret(t, "") // no fleet-wide secret, so the require-but-unconfigured path is exercised
 	settings := &botsfw.BotSettings{Code: "somebot", RequireWebhookSecret: true} // no secret set, but required
 	req := newWebhookRequest(t, "")
 	err := verifyWebhookSecretToken(context.Background(), req, settings)


### PR DESCRIPTION
## What

Adds a single, framework-owned standard for authenticating Telegram webhook requests across **all** bots.

Each bot's `secret_token` (registered with Telegram and verified on every incoming request via the `X-Telegram-Bot-Api-Secret-Token` header) is now resolved as:

1. the bot's own `BotSettings.WebhookSecretToken` if set (per-bot override, unchanged), else
2. the fleet-wide **`TELEGRAM_WEBHOOK_SECRET`** env var.

So one provisioned `TELEGRAM_WEBHOOK_SECRET` authenticates every bot's webhook with **no per-bot configuration** — eliminating the scattered per-bot `*_WEBHOOK_SECRET` setup. A bot that needs an isolated secret can still override via `WebhookSecretToken`.

## Why

Most bots currently ship **no** webhook secret, so their webhooks are unauthenticated (SEC-4 gap). Configuring a distinct secret per bot is high-friction. A single fleet secret closes the gap fleet-wide in one step.

## Behavior

- **`SetWebhook`** registers `effectiveWebhookSecret(settings)`.
- **`verifyWebhookSecretToken`** verifies against the same. Once any secret resolves (per-bot or fleet), verification is **strict** — missing or wrong header is rejected (this is the "enforce" posture, automatic once the secret is provisioned + webhooks re-registered). Telegram retries failed deliveries, so the brief re-registration window loses no updates.
- If neither resolves: unauthenticated compat posture (warn every request), unless `RequireWebhookSecret` → hard reject. Unchanged.

## Tests

8 new tests (resolver precedence, nil settings, match/wrong/missing header under fleet secret, per-bot value rejecting the fleet value) + 2 existing compat tests hardened to be env-independent. `go build`/`go vet`/`go test ./telegram/` all green.

## Rollout (consumer)

Provision `TELEGRAM_WEBHOOK_SECRET` once, mount on the service, bump this dep, then re-register each bot's webhook (`set-webhook`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AVzphdj4uLqkCEYuKFteV