### PR TITLE
feat(telegram): WithAdminPathPrefix to mount admin endpoints separately

### DIFF
--- a/telegram/tg_webhook_admin_prefix_test.go
+++ b/telegram/tg_webhook_admin_prefix_test.go
@@ -1,0 +1,81 @@
+package telegram
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/bots-go-framework/bots-fw/botsfw"
+	"github.com/bots-go-framework/bots-fw/mocks/mock_botsfw"
+	"github.com/strongo/i18n"
+	"go.uber.org/mock/gomock"
+)
+
+// fakeWebhookDriver is a no-op botsfw.WebhookDriver — RegisterHttpHandlers only needs
+// a non-nil driver to pass Register()'s guard; it never calls back into it here.
+type fakeWebhookDriver struct{}
+
+func (fakeWebhookDriver) RegisterWebhookHandlers(botsfw.HttpRouter, string, ...botsfw.WebhookHandler) {
+}
+func (fakeWebhookDriver) HandleWebhook(http.ResponseWriter, *http.Request, botsfw.WebhookHandler) {}
+
+// recordingRouter records the (method, path) of every route registered on it.
+type recordingRouter struct{ routes []string }
+
+func (rr *recordingRouter) Handle(method, path string, _ http.HandlerFunc) {
+	rr.routes = append(rr.routes, method+" "+path)
+}
+
+func (rr *recordingRouter) has(route string) bool {
+	for _, r := range rr.routes {
+		if r == route {
+			return true
+		}
+	}
+	return false
+}
+
+func registerAndRecord(t *testing.T, opts ...TgWebhookHandlerOption) *recordingRouter {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	var tp botsfw.TranslatorProvider = func(context.Context) i18n.Translator { return nil }
+	h := NewTelegramWebhookHandler(
+		mock_botsfw.NewMockBotContextProvider(ctrl), tp, testChatInstanceStore{}, opts...)
+	rr := &recordingRouter{}
+	h.RegisterHttpHandlers(fakeWebhookDriver{}, mock_botsfw.NewMockBotHost(ctrl), rr, "/bot")
+	return rr
+}
+
+// WithAdminPathPrefix moves the admin-only endpoints (set-webhook, test) under the
+// admin prefix, while the public /tg/hook endpoint stays under the public prefix.
+func TestRegisterHttpHandlers_WithAdminPathPrefix(t *testing.T) {
+	rr := registerAndRecord(t, WithAdminPathPrefix("/admin/bot"))
+
+	for _, want := range []string{
+		"POST /bot/tg/hook",               // public — Telegram POSTs here
+		"GET /admin/bot/tg/set-webhook",   // admin — moved under the admin prefix
+		"GET /admin/bot/tg/test/time-now", // admin — moved too
+	} {
+		if !rr.has(want) {
+			t.Errorf("route %q not registered; got %v", want, rr.routes)
+		}
+	}
+	if rr.has("GET /bot/tg/set-webhook") {
+		t.Errorf("set-webhook must NOT be under the public prefix when an admin prefix is set; got %v", rr.routes)
+	}
+}
+
+// Without an admin prefix, every endpoint stays under the public prefix (legacy behaviour).
+func TestRegisterHttpHandlers_NoAdminPathPrefix_LegacyLayout(t *testing.T) {
+	rr := registerAndRecord(t)
+
+	for _, want := range []string{
+		"POST /bot/tg/hook",
+		"GET /bot/tg/set-webhook",
+		"GET /bot/tg/test/time-now",
+	} {
+		if !rr.has(want) {
+			t.Errorf("route %q not registered; got %v", want, rr.routes)
+		}
+	}
+}

--- a/telegram/tg_webhook_handler.go
+++ b/telegram/tg_webhook_handler.go
@@ -39,8 +39,28 @@ type tgWebhookHandler struct {
 	botsfw.WebhookHandlerBase
 	botContextProvider botsfw.BotContextProvider
 	//botsBy botsfw.BotSettingsProvider
-	pathPrefix    string
-	chatInstances ChatInstanceStore
+	pathPrefix string
+	// adminPathPrefix, when non-empty, is the prefix the admin-only endpoints
+	// (set-webhook, test) mount under instead of pathPrefix — see WithAdminPathPrefix.
+	adminPathPrefix string
+	chatInstances   ChatInstanceStore
+}
+
+// TgWebhookHandlerOption configures a Telegram webhook handler at construction
+// time (functional-options pattern).
+type TgWebhookHandlerOption func(*tgWebhookHandler)
+
+// WithAdminPathPrefix mounts the admin-only endpoints (set-webhook and the test
+// route) under adminPrefix instead of the public webhook pathPrefix, so a host can
+// gate that prefix with admin auth. set-webhook (re-)points a bot's live webhook
+// using the bot's own token, so on a publicly reachable origin it must NOT be open.
+//
+// The public /tg/hook endpoint (which Telegram POSTs to) and the hook URL that
+// set-webhook registers with Telegram are unaffected — both keep using the public
+// pathPrefix. An empty adminPrefix (the default) preserves the legacy behaviour of
+// mounting every endpoint under the public pathPrefix.
+func WithAdminPathPrefix(adminPrefix string) TgWebhookHandlerOption {
+	return func(h *tgWebhookHandler) { h.adminPathPrefix = adminPrefix }
 }
 
 // NewTelegramWebhookHandler creates new Telegram webhooks handler
@@ -48,6 +68,7 @@ func NewTelegramWebhookHandler(
 	botContextProvider botsfw.BotContextProvider,
 	translatorProvider botsfw.TranslatorProvider,
 	chatInstances ChatInstanceStore,
+	opts ...TgWebhookHandlerOption,
 ) botsfw.WebhookHandler {
 	if botContextProvider == nil {
 		panic("botContextProvider == nil")
@@ -58,7 +79,7 @@ func NewTelegramWebhookHandler(
 	if chatInstances == nil {
 		panic("chatInstances == nil")
 	}
-	return tgWebhookHandler{
+	h := tgWebhookHandler{
 		botContextProvider: botContextProvider,
 		chatInstances:      chatInstances,
 		WebhookHandlerBase: botsfw.WebhookHandlerBase{
@@ -67,6 +88,10 @@ func NewTelegramWebhookHandler(
 			RecordsFieldsSetter: tgBotRecordsFieldsSetter{},
 		},
 	}
+	for _, opt := range opts {
+		opt(&h)
+	}
+	return h
 }
 
 func (h tgWebhookHandler) HandleUnmatched(whc botsfw.WebhookContext) (m botmsg.MessageFromBot) {
@@ -90,10 +115,20 @@ func (h tgWebhookHandler) RegisterHttpHandlers(driver botsfw.WebhookDriver, host
 
 	pathPrefix = strings.TrimSuffix(pathPrefix, "/")
 	h.pathPrefix = pathPrefix
+
+	// Admin-only endpoints (set-webhook, test) mount under adminPathPrefix when set,
+	// so a host can gate that prefix with admin auth; otherwise they fall back to the
+	// public pathPrefix (legacy behaviour). The public /tg/hook endpoint and the hook
+	// URL that set-webhook registers always use the public pathPrefix.
+	adminPrefix := strings.TrimSuffix(h.adminPathPrefix, "/")
+	if adminPrefix == "" {
+		adminPrefix = pathPrefix
+	}
+
 	//router.POST(pathPrefix+"/telegram/webhook", h.HandleWebhookRequest) // TODO: Remove obsolete
 	router.Handle("POST", pathPrefix+"/tg/hook", h.HandleWebhookRequest)
-	router.Handle("GET", pathPrefix+"/tg/set-webhook", h.SetWebhook)
-	router.Handle("GET", pathPrefix+"/tg/test/time-now", httpHandlerTestTimeNow)
+	router.Handle("GET", adminPrefix+"/tg/set-webhook", h.SetWebhook)
+	router.Handle("GET", adminPrefix+"/tg/test/time-now", httpHandlerTestTimeNow)
 }
 
 func httpHandlerTestTimeNow(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Why
`set-webhook` (re-)points a bot's live webhook to a URL derived from the request Host, using the bot's own token. On a publicly reachable origin (`--allow-unauthenticated` Cloud Run), leaving it open lets anyone hijack a bot's updates (and, once a `secret_token` is registered, leak it). It must be gated by admin auth.

## What
Add a functional option so the **host** decides where admin-only endpoints live and can gate that prefix:

- `NewTelegramWebhookHandler(..., opts ...TgWebhookHandlerOption)` — backward-compatible variadic.
- `WithAdminPathPrefix(prefix)` — mounts `set-webhook` + `test/time-now` under `prefix` (e.g. `/admin/bot`) instead of the public `pathPrefix`. The public `POST /tg/hook` and the hook URL that `set-webhook` registers with Telegram are unaffected (still the public prefix).
- Empty admin prefix → legacy single-prefix layout, unchanged.

Framework stays auth-agnostic: it only decides *where* admin endpoints mount; the host gates that prefix (e.g. sneat-go wraps `/admin/*` with its admin auth).

## Tests
`WithAdminPathPrefix` → set-webhook/test under the admin prefix, hook stays public, and set-webhook is NOT under the public prefix; plus the legacy no-prefix layout. `go build`/`vet`/`test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AVzphdj4uLqkCEYuKFteV