### PR TITLE
feat(telegram): TELEGRAM_WEBHOOK_REQUIRE_SECRET to fail closed

### DIFF
--- a/telegram/tg_webhook_handler.go
+++ b/telegram/tg_webhook_handler.go
@@ -241,6 +241,24 @@ const EnvTelegramWebhookSecret = "TELEGRAM_WEBHOOK_SECRET"
 // package var so tests can substitute a value without mutating the process environment.
 var resolveFleetWebhookSecret = func() string { return os.Getenv(EnvTelegramWebhookSecret) }
 
+// EnvTelegramRequireWebhookSecret, when truthy ("true"/"1"/"yes"/"on"), makes a missing
+// webhook secret a HARD FAILURE fleet-wide: if no secret resolves for a bot (neither a
+// per-bot WebhookSecretToken nor the fleet-wide TELEGRAM_WEBHOOK_SECRET), the webhook is
+// rejected rather than allowed with a warning. It is the fleet-wide equivalent of the
+// per-bot BotSettings.RequireWebhookSecret — set it in production so an accidentally-unset
+// secret fails CLOSED (bots reject) instead of silently serving unauthenticated webhooks.
+const EnvTelegramRequireWebhookSecret = "TELEGRAM_WEBHOOK_REQUIRE_SECRET"
+
+// resolveRequireWebhookSecret reports whether a webhook secret is required fleet-wide.
+// Indirected through a package var so tests can override without touching the environment.
+var resolveRequireWebhookSecret = func() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvTelegramRequireWebhookSecret))) {
+	case "true", "1", "yes", "on":
+		return true
+	}
+	return false
+}
+
 // effectiveWebhookSecret returns the secret_token to register (SetWebhook) and to verify
 // for a bot: the bot's own BotSettings.WebhookSecretToken when set, otherwise the
 // fleet-wide TELEGRAM_WEBHOOK_SECRET. It returns "" only when neither is configured, in
@@ -264,10 +282,11 @@ func effectiveWebhookSecret(settings *botsfw.BotSettings) string {
 // Compat posture: if no secret resolves for the bot - neither a per-bot WebhookSecretToken
 // nor the fleet-wide TELEGRAM_WEBHOOK_SECRET - this does NOT block the request (existing
 // deployments that haven't rolled out a secret yet keep working) but logs a high-visibility
-// warning on every single request so the gap is impossible to miss, unless
-// settings.RequireWebhookSecret is set, in which case an unconfigured secret is a hard
-// misconfiguration and the request is rejected. Once a secret IS configured (per-bot or
-// fleet-wide), verification is always strictly enforced.
+// warning on every single request so the gap is impossible to miss, unless a secret is
+// required (per-bot settings.RequireWebhookSecret or fleet-wide TELEGRAM_WEBHOOK_REQUIRE_SECRET),
+// in which case an unconfigured secret is a hard misconfiguration and the request is
+// rejected (fail closed). Once a secret IS configured (per-bot or fleet-wide), verification
+// is always strictly enforced.
 func verifyWebhookSecretToken(ctx context.Context, r *http.Request, settings *botsfw.BotSettings) error {
 	if settings == nil { // defensive: should not happen for a bot resolved via BotContextProvider
 		logus.Warningf(ctx, "SEC-4 WARNING: BotSettings is nil, cannot verify %s header - treating as unauthenticated", TelegramWebhookSecretTokenHeader)
@@ -275,10 +294,10 @@ func verifyWebhookSecretToken(ctx context.Context, r *http.Request, settings *bo
 	}
 	expected := effectiveWebhookSecret(settings)
 	if expected == "" {
-		if settings.RequireWebhookSecret {
+		if settings.RequireWebhookSecret || resolveRequireWebhookSecret() {
 			logus.Criticalf(ctx,
-				"SEC-4: rejecting Telegram webhook request for bot %q: RequireWebhookSecret is true but no WebhookSecretToken is configured",
-				settings.Code)
+				"SEC-4: rejecting Telegram webhook request for bot %q: a webhook secret is required (per-bot RequireWebhookSecret or fleet-wide %s) but none is configured (no per-bot WebhookSecretToken, no %s)",
+				settings.Code, EnvTelegramRequireWebhookSecret, EnvTelegramWebhookSecret)
 			return botsfw.ErrAuthFailed(fmt.Sprintf("webhook secret required but not configured for bot %q", settings.Code))
 		}
 		logus.Warningf(ctx,

--- a/telegram/tg_webhook_require_secret_test.go
+++ b/telegram/tg_webhook_require_secret_test.go
@@ -1,0 +1,52 @@
+package telegram
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bots-go-framework/bots-fw/botsfw"
+)
+
+// TELEGRAM_WEBHOOK_REQUIRE_SECRET makes a missing webhook secret fail CLOSED fleet-wide:
+// when no secret resolves for a bot, the webhook is rejected instead of allowed-with-warning.
+
+// withRequireWebhookSecret overrides the fleet-wide require flag for the duration of a test.
+func withRequireWebhookSecret(t *testing.T, require bool) {
+	t.Helper()
+	prev := resolveRequireWebhookSecret
+	resolveRequireWebhookSecret = func() bool { return require }
+	t.Cleanup(func() { resolveRequireWebhookSecret = prev })
+}
+
+// require=true + no secret resolvable (no per-bot, no fleet) → reject (fail closed).
+func TestVerifyWebhookSecretToken_FleetRequire_NoSecret_Rejects(t *testing.T) {
+	withFleetWebhookSecret(t, "")
+	withRequireWebhookSecret(t, true)
+	settings := &botsfw.BotSettings{Code: "somebot"}
+	req := newWebhookRequest(t, "")
+	assertAuthFailed(t, verifyWebhookSecretToken(context.Background(), req, settings))
+}
+
+// require=false + no secret → legacy compat (allow with warning).
+func TestVerifyWebhookSecretToken_FleetRequireOff_NoSecret_CompatAllows(t *testing.T) {
+	withFleetWebhookSecret(t, "")
+	withRequireWebhookSecret(t, false)
+	settings := &botsfw.BotSettings{Code: "somebot"}
+	req := newWebhookRequest(t, "")
+	if err := verifyWebhookSecretToken(context.Background(), req, settings); err != nil {
+		t.Errorf("verifyWebhookSecretToken() = %v, want nil (require off, no secret => compat allow)", err)
+	}
+}
+
+// require=true but a fleet secret IS set → the require branch is not reached; normal strict
+// verification applies (matching header passes, missing/wrong header rejects).
+func TestVerifyWebhookSecretToken_FleetRequire_WithSecret_NormalStrict(t *testing.T) {
+	withFleetWebhookSecret(t, "fleet-secret")
+	withRequireWebhookSecret(t, true)
+	settings := &botsfw.BotSettings{Code: "somebot"}
+
+	if err := verifyWebhookSecretToken(context.Background(), newWebhookRequest(t, "fleet-secret"), settings); err != nil {
+		t.Errorf("matching header should pass, got %v", err)
+	}
+	assertAuthFailed(t, verifyWebhookSecretToken(context.Background(), newWebhookRequest(t, ""), settings))
+}

--- a/telegram/tg_webhook_secret_token_test.go
+++ b/telegram/tg_webhook_secret_token_test.go
@@ -49,7 +49,8 @@ func TestVerifyWebhookSecretToken_MissingHeaderRejectedWhenSecretConfigured(t *t
 }
 
 func TestVerifyWebhookSecretToken_NoSecretConfigured_CompatAllowsByDefault(t *testing.T) {
-	withFleetWebhookSecret(t, "") // no fleet-wide secret either, so nothing resolves
+	withFleetWebhookSecret(t, "")                    // no fleet-wide secret either, so nothing resolves
+	withRequireWebhookSecret(t, false)               // and it is not required, so the compat path allows
 	settings := &botsfw.BotSettings{Code: "somebot"} // WebhookSecretToken left empty on purpose
 	req := newWebhookRequest(t, "")
 	if err := verifyWebhookSecretToken(context.Background(), req, settings); err != nil {
@@ -58,7 +59,7 @@ func TestVerifyWebhookSecretToken_NoSecretConfigured_CompatAllowsByDefault(t *te
 }
 
 func TestVerifyWebhookSecretToken_NoSecretConfigured_RequireWebhookSecretRejects(t *testing.T) {
-	withFleetWebhookSecret(t, "") // no fleet-wide secret, so the require-but-unconfigured path is exercised
+	withFleetWebhookSecret(t, "")                                                // no fleet-wide secret, so the require-but-unconfigured path is exercised
 	settings := &botsfw.BotSettings{Code: "somebot", RequireWebhookSecret: true} // no secret set, but required
 	req := newWebhookRequest(t, "")
 	err := verifyWebhookSecretToken(context.Background(), req, settings)


### PR DESCRIPTION
Fleet-wide fail-closed for webhook auth. When `TELEGRAM_WEBHOOK_REQUIRE_SECRET` is truthy and **no** secret resolves for a bot (no per-bot `WebhookSecretToken`, no fleet-wide `TELEGRAM_WEBHOOK_SECRET`), the webhook is **rejected** instead of allowed-with-warning — so an accidentally-unset fleet secret fails CLOSED rather than silently serving unauthenticated bots.

- `EnvTelegramRequireWebhookSecret` + `resolveRequireWebhookSecret` (var seam for tests)
- `verifyWebhookSecretToken`: the no-secret branch rejects when required (per-bot `RequireWebhookSecret` OR the fleet flag)
- Inert when a secret is set (the require branch isn't reached) — safe to enable in prod today
- Tests: require+no-secret → reject; require-off → compat allow; require+secret → normal strict

`go build`/`vet`/`test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AVzphdj4uLqkCEYuKFteV