### PR TITLE
Split Telegram router and feature responders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.25
 
 require (
 	github.com/bots-go-framework/bots-api-telegram v0.15.4-0.20260725163828-d6c8f595ea6f
-	github.com/bots-go-framework/bots-fw v0.77.1-0.20260725153915-199503fbe2af
+	github.com/bots-go-framework/bots-fw v0.77.1-0.20260725155310-2eeac7b0ff05
 	github.com/bots-go-framework/bots-fw-store v0.12.0
 	github.com/bots-go-framework/bots-fw-telegram-models v0.3.71
 	github.com/bots-go-framework/bots-go-core v0.2.5

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.25
 
 require (
 	github.com/bots-go-framework/bots-api-telegram v0.15.4-0.20260725163828-d6c8f595ea6f
-	github.com/bots-go-framework/bots-fw v0.77.0
+	github.com/bots-go-framework/bots-fw v0.77.1-0.20260725153915-199503fbe2af
 	github.com/bots-go-framework/bots-fw-store v0.12.0
 	github.com/bots-go-framework/bots-fw-telegram-models v0.3.71
 	github.com/bots-go-framework/bots-go-core v0.2.5

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.25
 
 require (
 	github.com/bots-go-framework/bots-api-telegram v0.15.4-0.20260725163828-d6c8f595ea6f
-	github.com/bots-go-framework/bots-fw v0.77.1-0.20260725155310-2eeac7b0ff05
+	github.com/bots-go-framework/bots-fw v0.77.1-0.20260725160245-13f2735fe248
 	github.com/bots-go-framework/bots-fw-store v0.12.0
 	github.com/bots-go-framework/bots-fw-telegram-models v0.3.71
 	github.com/bots-go-framework/bots-go-core v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/bots-go-framework/bots-fw v0.77.0 h1:9ncS/Ks+Cp7kfThzdIKvYqk6EbdaMNLp
 github.com/bots-go-framework/bots-fw v0.77.0/go.mod h1:gaVE8BOn9IUdCwbk38ik6RQ5SGBoeMNAyg9li6yBoO0=
 github.com/bots-go-framework/bots-fw v0.77.1-0.20260725153915-199503fbe2af h1:mzAI4uqzoqE0T9nO2hdsVmzJdOEBKfs50ftVi1LEKzE=
 github.com/bots-go-framework/bots-fw v0.77.1-0.20260725153915-199503fbe2af/go.mod h1:gaVE8BOn9IUdCwbk38ik6RQ5SGBoeMNAyg9li6yBoO0=
+github.com/bots-go-framework/bots-fw v0.77.1-0.20260725155310-2eeac7b0ff05 h1:owFjhmwwjj0IhazvGI+K5eF+s9aEp0sWjkjMJtGzcCc=
+github.com/bots-go-framework/bots-fw v0.77.1-0.20260725155310-2eeac7b0ff05/go.mod h1:gaVE8BOn9IUdCwbk38ik6RQ5SGBoeMNAyg9li6yBoO0=
 github.com/bots-go-framework/bots-fw-store v0.12.0 h1:oz2tCpsiTZ2WdeQhkG3H4vq44N24kxBUzXg1ie2nrRU=
 github.com/bots-go-framework/bots-fw-store v0.12.0/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
 github.com/bots-go-framework/bots-fw-telegram-models v0.3.71 h1:zTqJwBMncK6a769xpdbCvq4vXfCH4GSN7h+qqxJG9mM=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/bots-go-framework/bots-fw v0.77.1-0.20260725153915-199503fbe2af h1:mz
 github.com/bots-go-framework/bots-fw v0.77.1-0.20260725153915-199503fbe2af/go.mod h1:gaVE8BOn9IUdCwbk38ik6RQ5SGBoeMNAyg9li6yBoO0=
 github.com/bots-go-framework/bots-fw v0.77.1-0.20260725155310-2eeac7b0ff05 h1:owFjhmwwjj0IhazvGI+K5eF+s9aEp0sWjkjMJtGzcCc=
 github.com/bots-go-framework/bots-fw v0.77.1-0.20260725155310-2eeac7b0ff05/go.mod h1:gaVE8BOn9IUdCwbk38ik6RQ5SGBoeMNAyg9li6yBoO0=
+github.com/bots-go-framework/bots-fw v0.77.1-0.20260725160245-13f2735fe248 h1:91JnFuUGiz7jVKWMruHeOnZATBi8MiXpdTehkrmQyek=
+github.com/bots-go-framework/bots-fw v0.77.1-0.20260725160245-13f2735fe248/go.mod h1:gaVE8BOn9IUdCwbk38ik6RQ5SGBoeMNAyg9li6yBoO0=
 github.com/bots-go-framework/bots-fw-store v0.12.0 h1:oz2tCpsiTZ2WdeQhkG3H4vq44N24kxBUzXg1ie2nrRU=
 github.com/bots-go-framework/bots-fw-store v0.12.0/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
 github.com/bots-go-framework/bots-fw-telegram-models v0.3.71 h1:zTqJwBMncK6a769xpdbCvq4vXfCH4GSN7h+qqxJG9mM=

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/bots-go-framework/bots-fw v0.76.1 h1:3VmlPjKbUqU+ktOgLT02sUeQaEC6imjS
 github.com/bots-go-framework/bots-fw v0.76.1/go.mod h1:gaVE8BOn9IUdCwbk38ik6RQ5SGBoeMNAyg9li6yBoO0=
 github.com/bots-go-framework/bots-fw v0.77.0 h1:9ncS/Ks+Cp7kfThzdIKvYqk6EbdaMNLpjY+nAkVthGo=
 github.com/bots-go-framework/bots-fw v0.77.0/go.mod h1:gaVE8BOn9IUdCwbk38ik6RQ5SGBoeMNAyg9li6yBoO0=
+github.com/bots-go-framework/bots-fw v0.77.1-0.20260725153915-199503fbe2af h1:mzAI4uqzoqE0T9nO2hdsVmzJdOEBKfs50ftVi1LEKzE=
+github.com/bots-go-framework/bots-fw v0.77.1-0.20260725153915-199503fbe2af/go.mod h1:gaVE8BOn9IUdCwbk38ik6RQ5SGBoeMNAyg9li6yBoO0=
 github.com/bots-go-framework/bots-fw-store v0.12.0 h1:oz2tCpsiTZ2WdeQhkG3H4vq44N24kxBUzXg1ie2nrRU=
 github.com/bots-go-framework/bots-fw-store v0.12.0/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
 github.com/bots-go-framework/bots-fw-telegram-models v0.3.71 h1:zTqJwBMncK6a769xpdbCvq4vXfCH4GSN7h+qqxJG9mM=

--- a/telegram/tg_webhook_handler.go
+++ b/telegram/tg_webhook_handler.go
@@ -44,6 +44,7 @@ type tgWebhookHandler struct {
 	adminPathPrefix    string
 	chatInstances      ChatInstanceStore
 	responderTransform WebhookResponderTransform
+	routerResponderTransform WebhookResponderTransform
 }
 
 // TgWebhookHandlerOption configures a Telegram webhook handler at construction
@@ -64,6 +65,17 @@ func WithResponderTransform(transform WebhookResponderTransform) TgWebhookHandle
 		panic("transform == nil")
 	}
 	return func(h *tgWebhookHandler) { h.responderTransform = transform }
+}
+
+// WithRouterResponderTransform installs a transform used only for messages
+// returned through router dispatch. WebhookContext.Responder remains governed
+// by WithResponderTransform, so feature direct sends cannot obtain router-only
+// command authority.
+func WithRouterResponderTransform(transform WebhookResponderTransform) TgWebhookHandlerOption {
+	if transform == nil {
+		panic("transform == nil")
+	}
+	return func(h *tgWebhookHandler) { h.routerResponderTransform = transform }
 }
 
 // WithAdminPathPrefix mounts the admin-only endpoints (set-webhook and the test
@@ -419,9 +431,23 @@ func (h tgWebhookHandler) CreateWebhookContext(
 
 func (h tgWebhookHandler) GetResponder(w http.ResponseWriter, whc botsfw.WebhookContext) botsfw.WebhookResponder {
 	if twhc, ok := whc.(*tgWebhookContext); ok {
-		return h.installResponder(twhc, newTgWebhookResponder(w, twhc))
+		raw := botsfw.WebhookResponder(newTgWebhookResponder(w, twhc))
+		if h.routerResponderTransform != nil {
+			twhc.routerResponder = h.routerResponderTransform(twhc, raw)
+			if twhc.routerResponder == nil {
+				panic("Router WebhookResponderTransform returned nil")
+			}
+		}
+		return h.installResponder(twhc, raw)
 	}
 	panic(fmt.Sprintf("Expected tgWebhookContext, got: %T", whc))
+}
+
+func (h tgWebhookHandler) GetRouterResponder(whc botsfw.WebhookContext, responder botsfw.WebhookResponder) botsfw.WebhookResponder {
+	if twhc, ok := whc.(*tgWebhookContext); ok && twhc.routerResponder != nil {
+		return twhc.routerResponder
+	}
+	return responder
 }
 
 func (h tgWebhookHandler) installResponder(whc *tgWebhookContext, responder botsfw.WebhookResponder) botsfw.WebhookResponder {

--- a/telegram/tg_webhook_handler.go
+++ b/telegram/tg_webhook_handler.go
@@ -41,13 +41,30 @@ type tgWebhookHandler struct {
 	pathPrefix string
 	// adminPathPrefix, when non-empty, is the prefix the admin-only endpoints
 	// (set-webhook, test) mount under instead of pathPrefix — see WithAdminPathPrefix.
-	adminPathPrefix string
-	chatInstances   ChatInstanceStore
+	adminPathPrefix    string
+	chatInstances      ChatInstanceStore
+	responderTransform WebhookResponderTransform
 }
 
 // TgWebhookHandlerOption configures a Telegram webhook handler at construction
 // time (functional-options pattern).
 type TgWebhookHandlerOption func(*tgWebhookHandler)
+
+// WebhookResponderTransform wraps the responder used for a single webhook.
+// The transformed responder is installed into WebhookContext as well as passed
+// to router dispatch, so direct responder sends and router-returned messages
+// share one host-enforced delivery boundary.
+type WebhookResponderTransform func(botsfw.WebhookResponder) botsfw.WebhookResponder
+
+// WithResponderTransform installs a host-owned responder transform. The
+// transform is applied once per webhook after the Telegram responder has been
+// created and before any router action can run.
+func WithResponderTransform(transform WebhookResponderTransform) TgWebhookHandlerOption {
+	if transform == nil {
+		panic("transform == nil")
+	}
+	return func(h *tgWebhookHandler) { h.responderTransform = transform }
+}
 
 // WithAdminPathPrefix mounts the admin-only endpoints (set-webhook and the test
 // route) under adminPrefix instead of the public webhook pathPrefix, so a host can
@@ -402,9 +419,20 @@ func (h tgWebhookHandler) CreateWebhookContext(
 
 func (h tgWebhookHandler) GetResponder(w http.ResponseWriter, whc botsfw.WebhookContext) botsfw.WebhookResponder {
 	if twhc, ok := whc.(*tgWebhookContext); ok {
-		return newTgWebhookResponder(w, twhc)
+		return h.installResponder(twhc, newTgWebhookResponder(w, twhc))
 	}
 	panic(fmt.Sprintf("Expected tgWebhookContext, got: %T", whc))
+}
+
+func (h tgWebhookHandler) installResponder(whc *tgWebhookContext, responder botsfw.WebhookResponder) botsfw.WebhookResponder {
+	if h.responderTransform != nil {
+		responder = h.responderTransform(responder)
+		if responder == nil {
+			panic("WebhookResponderTransform returned nil")
+		}
+	}
+	whc.responder = responder
+	return responder
 }
 
 //func (h tgWebhookHandler) CreateBotCoreStores(appContext botsfw.BotAppContext, r *http.Request) botsfwdal.DataAccess {

--- a/telegram/tg_webhook_handler.go
+++ b/telegram/tg_webhook_handler.go
@@ -54,7 +54,7 @@ type TgWebhookHandlerOption func(*tgWebhookHandler)
 // The transformed responder is installed into WebhookContext as well as passed
 // to router dispatch, so direct responder sends and router-returned messages
 // share one host-enforced delivery boundary.
-type WebhookResponderTransform func(botsfw.WebhookResponder) botsfw.WebhookResponder
+type WebhookResponderTransform func(botsfw.WebhookContext, botsfw.WebhookResponder) botsfw.WebhookResponder
 
 // WithResponderTransform installs a host-owned responder transform. The
 // transform is applied once per webhook after the Telegram responder has been
@@ -426,7 +426,7 @@ func (h tgWebhookHandler) GetResponder(w http.ResponseWriter, whc botsfw.Webhook
 
 func (h tgWebhookHandler) installResponder(whc *tgWebhookContext, responder botsfw.WebhookResponder) botsfw.WebhookResponder {
 	if h.responderTransform != nil {
-		responder = h.responderTransform(responder)
+		responder = h.responderTransform(whc, responder)
 		if responder == nil {
 			panic("WebhookResponderTransform returned nil")
 		}

--- a/telegram/tg_webhook_handler_test.go
+++ b/telegram/tg_webhook_handler_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/bots-go-framework/bots-api-telegram/tgbotapi"
 	"github.com/bots-go-framework/bots-fw-telegram-models/botsfwtgmodels"
 	"github.com/bots-go-framework/bots-fw/botinput"
+	"github.com/bots-go-framework/bots-fw/botmsg"
 	"github.com/bots-go-framework/bots-fw/botsfw"
 	"github.com/bots-go-framework/bots-fw/mocks/mock_botsfw"
+	"github.com/bots-go-framework/bots-go-core/botkb"
 	"github.com/strongo/i18n"
 	"go.uber.org/mock/gomock"
 	"net/http"
@@ -24,6 +26,60 @@ func (testChatInstanceStore) Get(context.Context, string, string) (botsfwtgmodel
 }
 func (testChatInstanceStore) Save(context.Context, string, string, botsfwtgmodels.TgChatInstanceData) error {
 	return nil
+}
+
+type recordingResponder struct{ sends int }
+
+func (r *recordingResponder) SendMessage(_ context.Context, _ botmsg.MessageFromBot, _ botmsg.BotAPISendMessageChannel) (botsfw.OnMessageSentResponse, error) {
+	r.sends++
+	return botsfw.OnMessageSentResponse{}, nil
+}
+
+func (*recordingResponder) DeleteMessage(context.Context, string) error { return nil }
+
+func bottomKeyboardMessage(kind botkb.KeyboardType) botmsg.MessageFromBot {
+	message := botmsg.MessageFromBot{}
+	message.Keyboard = botkb.NewMessageKeyboard(kind)
+	return message
+}
+
+func TestResponderTransformGatesRouterAndDirectPaths(t *testing.T) {
+	raw := &recordingResponder{}
+	handler := tgWebhookHandler{responderTransform: func(next botsfw.WebhookResponder) botsfw.WebhookResponder {
+		return botsfw.NewPolicyResponder(next, botsfw.PresentationPolicy{PersistentBottomKeyboard: botsfw.PersistentBottomKeyboardHostOnly})
+	}}
+	whc := &tgWebhookContext{}
+	routerResponder := handler.installResponder(whc, raw)
+	message := bottomKeyboardMessage(botkb.KeyboardTypeBottom)
+	if _, err := routerResponder.SendMessage(context.Background(), message, botsfw.BotAPISendMessageOverHTTPS); err == nil || !strings.Contains(err.Error(), "reserved for the host") {
+		t.Fatalf("router-return message error = %v", err)
+	}
+	if _, err := whc.Responder().SendMessage(context.Background(), message, botsfw.BotAPISendMessageOverHTTPS); err == nil || !strings.Contains(err.Error(), "reserved for the host") {
+		t.Fatalf("direct message error = %v", err)
+	}
+	if raw.sends != 0 {
+		t.Fatalf("gated sends reached raw responder %d times", raw.sends)
+	}
+}
+
+func TestResponderTransformAllowsHostHomeHideAndInlineMessages(t *testing.T) {
+	raw := &recordingResponder{}
+	handler := tgWebhookHandler{responderTransform: func(next botsfw.WebhookResponder) botsfw.WebhookResponder {
+		return botsfw.NewHostPolicyResponder(next, botsfw.PresentationPolicy{PersistentBottomKeyboard: botsfw.PersistentBottomKeyboardHostOnly})
+	}}
+	whc := &tgWebhookContext{}
+	responder := handler.installResponder(whc, raw)
+	for _, kind := range []botkb.KeyboardType{botkb.KeyboardTypeBottom, botkb.KeyboardTypeHide, botkb.KeyboardTypeInline} {
+		if _, err := responder.SendMessage(context.Background(), bottomKeyboardMessage(kind), botsfw.BotAPISendMessageOverHTTPS); err != nil {
+			t.Fatalf("host %v message: %v", kind, err)
+		}
+	}
+	if whc.Responder() != responder {
+		t.Fatal("transformed responder was not installed in webhook context")
+	}
+	if raw.sends != 3 {
+		t.Fatalf("host sends = %d, want 3", raw.sends)
+	}
 }
 
 func TestNewTelegramWebhookHandler(t *testing.T) {

--- a/telegram/tg_webhook_handler_test.go
+++ b/telegram/tg_webhook_handler_test.go
@@ -45,7 +45,7 @@ func bottomKeyboardMessage(kind botkb.KeyboardType) botmsg.MessageFromBot {
 
 func TestResponderTransformGatesRouterAndDirectPaths(t *testing.T) {
 	raw := &recordingResponder{}
-	handler := tgWebhookHandler{responderTransform: func(next botsfw.WebhookResponder) botsfw.WebhookResponder {
+	handler := tgWebhookHandler{responderTransform: func(_ botsfw.WebhookContext, next botsfw.WebhookResponder) botsfw.WebhookResponder {
 		return botsfw.NewPolicyResponder(next, botsfw.PresentationPolicy{PersistentBottomKeyboard: botsfw.PersistentBottomKeyboardHostOnly})
 	}}
 	whc := &tgWebhookContext{}
@@ -64,7 +64,7 @@ func TestResponderTransformGatesRouterAndDirectPaths(t *testing.T) {
 
 func TestResponderTransformAllowsHostHomeHideAndInlineMessages(t *testing.T) {
 	raw := &recordingResponder{}
-	handler := tgWebhookHandler{responderTransform: func(next botsfw.WebhookResponder) botsfw.WebhookResponder {
+	handler := tgWebhookHandler{responderTransform: func(_ botsfw.WebhookContext, next botsfw.WebhookResponder) botsfw.WebhookResponder {
 		return botsfw.NewHostPolicyResponder(next, botsfw.PresentationPolicy{PersistentBottomKeyboard: botsfw.PersistentBottomKeyboardHostOnly})
 	}}
 	whc := &tgWebhookContext{}

--- a/telegram/webhook_context_tg.go
+++ b/telegram/webhook_context_tg.go
@@ -21,6 +21,7 @@ type tgWebhookContext struct {
 	//update         tgbotapi.Update // TODO: Consider removing?
 	//responseWriter http.ResponseWriter
 	responder botsfw.WebhookResponder
+	routerResponder botsfw.WebhookResponder
 	//whi          tgInput
 
 	// This 3 props are cache for getLocalAndChatIDByChatInstance()


### PR DESCRIPTION
## What changed

- Add public Telegram responder-transform options for feature direct sends and router-returned messages.
- Install the transformed feature responder into WebhookContext.
- Retain a separately transformed router responder for the framework driver to use during dispatch.
- Pass webhook context into transforms so host composition can choose dedicated versus embedded policy by profile.

## Security invariant

Feature code can obtain only WebhookContext.Responder(), the feature gate. Router-only command capability is not stored in the context. This prevents embedded features from self-selecting host keyboard authority while preserving host-owned router responses.

## Validation

- go test -race ./telegram
- go vet ./...
- router and direct paths gate embedded bottom keyboards; host bottom/Home, hide/remove, and inline paths pass through the host configuration.

## Dependency

Requires the bots-fw policy/router stack: #89 then #91 then #92 then #93. Pin bots-fw commit e0a63d6 after that stack is merged/tagged; this draft currently pins the exact branch artifact.